### PR TITLE
Add necessary header file from c++11

### DIFF
--- a/src/honestRF.h
+++ b/src/honestRF.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <functional>
 #include "DataFrame.h"
 #include "honestRFTree.h"
 


### PR DESCRIPTION
On Linux with a gcc compiler, I wasn't able to compile directly from your github.

```
honestRF.cpp: In member function ‘void honestRF::addTrees(size_t)’:
honestRF.cpp:103:29: error: ‘bind’ is not a member of ‘std’
     auto dummyThread = std::bind(
                             ^~~~
honestRF.cpp:103:29: note: suggested alternative: ‘find’
     auto dummyThread = std::bind(
                             ^~~~
                             find
honestRF.cpp: In member function ‘std::unique_ptr<std::vector<double> > honestRF::predict(std::vector<std::vector<double> >*)’:
honestRF.cpp:260:29: error: ‘bind’ is not a member of ‘std’
     auto dummyThread = std::bind(
                             ^~~~
honestRF.cpp:260:29: note: suggested alternative: ‘find’
     auto dummyThread = std::bind(
                             ^~~~
                             find
honestRF.cpp: In member function ‘void honestRF::calculateOOBError()’:
honestRF.cpp:349:29: error: ‘bind’ is not a member of ‘std’
     auto dummyThread = std::bind(
                             ^~~~
honestRF.cpp:349:29: note: suggested alternative: ‘find’
     auto dummyThread = std::bind(
                             ^~~~
                             find
make: *** [/usr/lib64/R/etc/Makeconf:168: honestRF.o] Error 1
ERROR: compilation failed for package ‘hte’
* removing ‘/home/steve/R/x86_64-pc-linux-gnu-library/3.5/hte’
Installation failed: Command failed (1)
```
Adding this header fixes the issue.